### PR TITLE
README.md error with code in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The file sizes:
 ```
 npm install --save-dev css-uncut
 ```
+```
  480K - i.css        (uncompresed)
  390K - i.min.css    (minified)
   47K - i.min.css.gz (minified & gzipped)


### PR DESCRIPTION
One of the code snippets did not have an opening set of "```". I've fixed it here out of OCD.